### PR TITLE
Fix BuildClient function 

### DIFF
--- a/Source/STOMPWebSockets/Private/STOMPWebSocketClient.cpp
+++ b/Source/STOMPWebSockets/Private/STOMPWebSocketClient.cpp
@@ -54,11 +54,21 @@ void USTOMPWebSocketClient::TickComponent(float DeltaTime, ELevelTick TickType, 
  */
 void USTOMPWebSocketClient::BuildClient()
 {
-	if (StompClient.Get() != nullptr)
+	if (StompClient.IsValid())
 	{
-		StompClient.Get()->Disconnect();
+		if (StompClient.Get()->IsConnected())
+		{
+			StompClient.Get()->Disconnect();
+		}
+
+		StompClient->OnConnected().Clear();
+		StompClient->OnConnectionError().Clear();
+		StompClient->OnError().Clear();
+		StompClient->OnClosed().Clear();	
+
 		delete StompClient.Get();
 	}
+
 	
 	FStompModule* stompModule = &FStompModule::Get();
 	StompClient = stompModule->CreateClient(Url, AuthToken);

--- a/Source/STOMPWebSockets/Private/STOMPWebSocketClient.cpp
+++ b/Source/STOMPWebSockets/Private/STOMPWebSocketClient.cpp
@@ -54,6 +54,12 @@ void USTOMPWebSocketClient::TickComponent(float DeltaTime, ELevelTick TickType, 
  */
 void USTOMPWebSocketClient::BuildClient()
 {
+	if (StompClient.Get() != nullptr)
+	{
+		StompClient.Get()->Disconnect();
+		delete StompClient.Get();
+	}
+	
 	FStompModule* stompModule = &FStompModule::Get();
 	StompClient = stompModule->CreateClient(Url, AuthToken);
 


### PR DESCRIPTION
Calling BuildClient function twice causes a crash. I use it to reconnect after token expiry.  On my machine this fix works. I send plugin folder to the colleague, but he has crashes. 
Also we use UE 4.27 for project. Can you add plugin support for this version? 
![image](https://github.com/Ruzihm/STOMPWebSocketsPlugin/assets/40485432/cabaea2d-a7e9-43f1-be38-759fce870133)
